### PR TITLE
Add initial repo template based on https://github.com/ni/Github-Repo-Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+[ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).
+
+TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).
+
+### What does this Pull Request accomplish?
+
+TODO: Include high-level description of the changes in this pull request.
+
+### Why should this Pull Request be merged?
+
+TODO: Justify why this contribution should be part of the project.
+
+### What testing has been done?
+
+TODO: Detail what testing has been done to ensure this submission meets requirements.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Contributions to systemlink-OpenAPI-documents are welcome from all!
 
 systemlink-OpenAPI-documents is managed via [git](https://git-scm.com), with the canonical upstream
-repository hosted on [GitHub](http://developercertificate.org/).
+repository hosted on [GitHub](https://github.com/ni/systemlink-OpenAPI-documents/).
 
 systemlink-OpenAPI-documents follows a pull-request model for development.  If you wish to
 contribute, you will need to create a GitHub account, fork this project, push a
@@ -13,7 +13,7 @@ See [GitHub's official documentation](https://help.github.com/articles/using-pul
 
 # Testing
 
-Before making a pull request, ensure that there are no syntax errors in your document by pasting it into editor.swagger.io.
+Before making a pull request, ensure that there are no syntax errors in your document by pasting it into [editor.swagger.io](https://editor.swagger.io).
 
 # Developer Certificate of Origin (DCO)
 
@@ -43,7 +43,7 @@ Before making a pull request, ensure that there are no syntax errors in your doc
        maintained indefinitely and may be redistributed consistent with
        this project or the open source license(s) involved.
 
-(taken from [developercertificate.org](http://developercertificate.org/))
+(taken from [developercertificate.org](https://developercertificate.org/))
 
 See [LICENSE](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/LICENSE)
 for details about how systemlink-OpenAPI-documents is licensed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing to systemlink-OpenAPI-documents 
+
+Contributions to systemlink-OpenAPI-documents are welcome from all!
+
+systemlink-OpenAPI-documents is managed via [git](https://git-scm.com), with the canonical upstream
+repository hosted on [GitHub](http://developercertificate.org/).
+
+systemlink-OpenAPI-documents follows a pull-request model for development.  If you wish to
+contribute, you will need to create a GitHub account, fork this project, push a
+branch with your changes to your project, and then submit a pull request.
+
+See [GitHub's official documentation](https://help.github.com/articles/using-pull-requests/) for more details.
+
+# Testing
+
+Before making a pull request, ensure that there are no syntax errors in your document by pasting it into editor.swagger.io.
+
+# Developer Certificate of Origin (DCO)
+
+   Developer's Certificate of Origin 1.1
+
+   By making a contribution to this project, I certify that:
+
+   (a) The contribution was created in whole or in part by me and I
+       have the right to submit it under the open source license
+       indicated in the file; or
+
+   (b) The contribution is based upon previous work that, to the best
+       of my knowledge, is covered under an appropriate open source
+       license and I have the right under that license to submit that
+       work with modifications, whether created in whole or in part
+       by me, under the same open source license (unless I am
+       permitted to submit under a different license), as indicated
+       in the file; or
+
+   (c) The contribution was provided directly to me by some other
+       person who certified (a), (b) or (c) and I have not modified
+       it.
+
+   (d) I understand and agree that this project and the contribution
+       are public and that a record of the contribution (including all
+       personal information I submit with it, including my sign-off) is
+       maintained indefinitely and may be redistributed consistent with
+       this project or the open source license(s) involved.
+
+(taken from [developercertificate.org](http://developercertificate.org/))
+
+See [LICENSE](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/LICENSE)
+for details about how systemlink-OpenAPI-documents is licensed.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2018, National Instruments Corp.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SystemLink OpenAPI Documents
 
-This repository contains OpenAPI documents which describe some of the HTTP APIs exposed by web services in SystemLink and SystemLink Cloud.
+This repository contains OpenAPI documents which describe some of the HTTP APIs provided by web services in SystemLink and SystemLink Cloud.
 
 ## Using an OpenAPI document to generate a client
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# SystemLink OpenAPI Documents
+
+This repository contains OpenAPI documents which describe some of the HTTP APIs exposed by web services in SystemLink and SystemLink Cloud.
+
+## Using an OpenAPI document to generate a client
+
+To generate a client from an OpenAPI document, paste the document into editor.swagger.io, click "Generate Client", and select a language.

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This repository contains OpenAPI documents which describe some of the HTTP APIs 
 
 ## Using an OpenAPI document to generate a client
 
-To generate a client from an OpenAPI document, paste the document into editor.swagger.io, click "Generate Client", and select a language.
+To generate a client from an OpenAPI document, paste the document into [editor.swagger.io](https://editor.swagger.io), click "Generate Client", and select a language.


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Adds a minimal GitHub repository template, which is expected of all repos hosted under github.com/ni.

@jjaco2 : feel free to just review the stuff in README.md, as that's essentially user-facing documentation. I consider all of that to be pretty rough, and I imagine we'll just replace it with links to whatever Swagger documentation we end up creating on ni.com.

### Why should this Pull Request be merged?
A repo template is expected to be present in all repos hosted under github.com/ni.

### What testing has been done?
N/A
