### PR TITLE
Add get routes for results and steps

### DIFF
--- a/test-monitor/nitestmonitor.yml
+++ b/test-monitor/nitestmonitor.yml
@@ -88,6 +88,8 @@ definitions:
       operations:
         description: >-
           Available operations in the v1 version of the API:
+          - getResults: The ability to get test results
+
           - queryResults: The ability to query test results
 
           - createResults: The ability to create test results
@@ -97,6 +99,8 @@ definitions:
           - deleteResult: The ability to delete test results
 
           - deleteManyResults: The ability to delete multiple test results
+
+          - getSteps: The ability to get test steps
 
           - querySteps: The ability to query test steps
 
@@ -110,6 +114,8 @@ definitions:
 
         type: object
         properties:
+          getResults:
+            $ref: '#/definitions/Operation'
           queryResults:
             $ref: '#/definitions/Operation'
           createResults:
@@ -119,6 +125,8 @@ definitions:
           deleteResult:
             $ref: '#/definitions/Operation'
           deleteManyResults:
+            $ref: '#/definitions/Operation'
+          getSteps:
             $ref: '#/definitions/Operation'
           querySteps:
             $ref: '#/definitions/Operation'

--- a/test-monitor/nitestmonitor.yml
+++ b/test-monitor/nitestmonitor.yml
@@ -978,6 +978,29 @@ paths:
         default:
           $ref: '#/responses/Error'
   /v1/results:
+    get:
+      tags: [results]
+      summary: Gets test results
+      description: Gets a list of test results.
+      operationId: get-results
+      x-ni-operation: getResults
+      x-ni-privilege: Read
+      parameters:
+        - in: query
+          name: skip
+          type: integer
+          default: 0
+        - in: query
+          name: take
+          type: integer
+          default: -1
+      responses:
+        200:
+          $ref: '#/responses/ResultsQueryResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
     put:
       tags: [results]
       summary: Updates existing test results
@@ -1146,6 +1169,29 @@ paths:
         default:
           $ref: '#/responses/Error'
   /v1/steps:
+    get:
+      tags: [steps]
+      summary: Gets test steps
+      description: Gets a list of test steps.
+      operationId: get-steps
+      x-ni-operation: getSteps
+      x-ni-privilege: Read
+      parameters:
+        - in: query
+          name: skip
+          type: integer
+          default: 0
+        - in: query
+          name: take
+          type: integer
+          default: -1
+      responses:
+        200:
+          $ref: '#/responses/StepsQueryResponse'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
     put:
       tags: [steps]
       summary: Update test steps


### PR DESCRIPTION
[x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This adds two new GET routes to the API to make it more RESTful.  Previously, there were no GET routes at all.  These endpoints call through to the underlying query handler, with no filters applied.  It allows for basic skip/take without filtering.

### Why should this Pull Request be merged?

Updating the public documentation to match the implementation of the backend.

### What testing has been done?

Tested the 2 new routes as well as the base permissions routes.  Verified they behave as expected.
