### PR TITLE
Add new query parameter to step routes

### DIFF
--- a/test-monitor/nitestmonitor.yml
+++ b/test-monitor/nitestmonitor.yml
@@ -1249,7 +1249,7 @@ paths:
             $ref: '#/definitions/TestStepCreateOrUpdateRequestObject'
         - in: query
           name: updateResultTotalTime
-          description: Determine test result total time from the test step total times. Added in 18.5.
+          description: Determine test result total time from the test step total times. Added in version 2.
           type: boolean
           default: false
       responses:
@@ -1275,7 +1275,7 @@ paths:
             $ref: '#/definitions/TestStepCreateOrUpdateRequestObject'
         - in: query
           name: updateResultTotalTime
-          description: Determine test result total time from the test step total times. Added in 18.5.
+          description: Determine test result total time from the test step total times. Added in version 2.
           type: boolean
           default: false
       responses:
@@ -1308,7 +1308,7 @@ paths:
           required: true
         - in: query
           name: updateResultTotalTime
-          description: Determine test result total time from the test step total times. Added in 18.5.
+          description: Determine test result total time from the test step total times. Added in version 2.
           type: boolean
           default: false
       responses:
@@ -1335,7 +1335,7 @@ paths:
             $ref: '#/definitions/TestStepsDeleteRequest'
         - in: query
           name: updateResultTotalTime
-          description: Determine test result total time from the test step total times. Added in 18.5.
+          description: Determine test result total time from the test step total times. Added in version 2.
           type: boolean
           default: false
       responses:

--- a/test-monitor/nitestmonitor.yml
+++ b/test-monitor/nitestmonitor.yml
@@ -1249,7 +1249,7 @@ paths:
             $ref: '#/definitions/TestStepCreateOrUpdateRequestObject'
         - in: query
           name: updateResultTotalTime
-          description: Determine test result total time from the test step total times
+          description: Determine test result total time from the test step total times. Added in 18.5.
           type: boolean
           default: false
       responses:
@@ -1275,7 +1275,7 @@ paths:
             $ref: '#/definitions/TestStepCreateOrUpdateRequestObject'
         - in: query
           name: updateResultTotalTime
-          description: Determine test result total time from the test step total times
+          description: Determine test result total time from the test step total times. Added in 18.5.
           type: boolean
           default: false
       responses:
@@ -1308,7 +1308,7 @@ paths:
           required: true
         - in: query
           name: updateResultTotalTime
-          description: Determine test result total time from the test step total times
+          description: Determine test result total time from the test step total times. Added in 18.5.
           type: boolean
           default: false
       responses:
@@ -1335,7 +1335,7 @@ paths:
             $ref: '#/definitions/TestStepsDeleteRequest'
         - in: query
           name: updateResultTotalTime
-          description: Determine test result total time from the test step total times
+          description: Determine test result total time from the test step total times. Added in 18.5.
           type: boolean
           default: false
       responses:

--- a/test-monitor/nitestmonitor.yml
+++ b/test-monitor/nitestmonitor.yml
@@ -1247,6 +1247,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/TestStepCreateOrUpdateRequestObject'
+        - in: query
+          name: updateResultTotalTime
+          description: Determine test result total time from the test step total times
+          type: boolean
+          default: false
       responses:
         200:
           $ref: '#/responses/StepsPartialSuccessResponse'
@@ -1268,6 +1273,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/TestStepCreateOrUpdateRequestObject'
+        - in: query
+          name: updateResultTotalTime
+          description: Determine test result total time from the test step total times
+          type: boolean
+          default: false
       responses:
         200:
           $ref: '#/responses/StepsPartialSuccessResponse'
@@ -1296,6 +1306,11 @@ paths:
           description: Id of the test step to delete
           type: string
           required: true
+        - in: query
+          name: updateResultTotalTime
+          description: Determine test result total time from the test step total times
+          type: boolean
+          default: false
       responses:
         204:
           description: The resource was deleted successfully.
@@ -1318,6 +1333,11 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/TestStepsDeleteRequest'
+        - in: query
+          name: updateResultTotalTime
+          description: Determine test result total time from the test step total times
+          type: boolean
+          default: false
       responses:
         200:
           $ref: '#/responses/StepsDeletePartialSuccessResponse'


### PR DESCRIPTION
[X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds the `updateResultTotalTime` query parameter to all write-permissioned routes for the Steps collection. This is an ease-of-use feature for HTTP clients.

### Why should this Pull Request be merged?

Updating public documentation to match backend changes.

### What testing has been done?

Tested the query parameters on a locally installed instance.
