### PR TITLE
OpenAPI Tag: Specify mean instead of average in descriptions

### DIFF
--- a/tag/nitag.yml
+++ b/tag/nitag.yml
@@ -762,7 +762,7 @@ paths:
       tags:
         - selections
       summary: Get the "avg" aggregate values for the tags in a selection
-      description: Returns the average aggregate values for the tags in a selection
+      description: Returns the mean aggregate values for the tags in a selection
       operationId: GetSelectionMeanValues
       parameters:
         - in: path
@@ -1567,7 +1567,7 @@ definitions:
         description: Count aggregate value
         type: integer
       avg:
-        description: Average aggregate value
+        description: Mean aggregate value
         type: number
     example:
       min: 0
@@ -1589,7 +1589,7 @@ definitions:
         description: Count aggregate value
         type: integer
       avg:
-        description: Average aggregate value
+        description: Mean aggregate value
         type: number
     example:
       min: "0.0"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates the Swagger document for nitag to indicate the mean instead of average to match guidelines we've used elsewhere.

### Why should this Pull Request be merged?

Clarifies that the "avg" aggregate value is the mean of tag values.

### What testing has been done?

N/A, description-only change.
