### PR TITLE
nitag: Add additionalProperties to tag properties

### DIFF
--- a/tag/nitag.yml
+++ b/tag/nitag.yml
@@ -1606,6 +1606,8 @@ definitions:
         $ref: '#/definitions/TagType'
       properties:
         type: object
+        additionalProperties:
+          type: string
       path:
         type: string
       keywords:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enables code generators to treat tag properties as string key-value pairs instead of a generic object.

### Why should this Pull Request be merged?

More accurately describes tag properties so generated code doesn't require dynamic type inspection.

### What testing has been done?

Generated a C# client and verified the Tag class now represents the properties as a `Dictionary<string, string>` instead of `Object`.