### PR TITLE
nitag: Correct selection responses

### DIFF
--- a/tag/nitag.yml
+++ b/tag/nitag.yml
@@ -415,7 +415,9 @@ paths:
           required: true
       responses:
         200:
-          $ref: '#/definitions/Selection'
+          description: Success
+          schema:
+            $ref: '#/definitions/Selection'
         400:
           description: Bad Request
         401:
@@ -461,7 +463,9 @@ paths:
           required: true
       responses:
         200:
-          $ref: '#/definitions/Selection'
+          description: Success
+          schema:
+            $ref: '#/definitions/Selection'
         400:
           description: Bad Request
         401:
@@ -482,7 +486,9 @@ paths:
           required: true
       responses:
         200:
-          $ref: '#/definitions/Selection'
+          description: Success
+          schema:
+            $ref: '#/definitions/Selection'
         401:
           $ref: '#/responses/Unauthorized'
         default:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fixes responses to reference a schema instead of directly referencing the definition. Swagger UI shows the model under the response, but codegen ignores the definition, resulting in void methods.

### Why should this Pull Request be merged?

Enables generated clients to use the selection APIs.

### What testing has been done?

Generated a C# client from the updated document and verified the selection methods are no longer void.
