### PR TITLE
Add new "Product" field to Test Monitor results

### DIFF
--- a/test-monitor/nitestmonitor.yml
+++ b/test-monitor/nitestmonitor.yml
@@ -179,6 +179,7 @@ definitions:
       - HOST_NAME
       - OPERATOR
       - SERIAL_NUMBER
+      - PRODUCT
       - TOTAL_TIME_IN_SECONDS
       - KEYWORDS
       - PROPERTIES
@@ -312,6 +313,10 @@ definitions:
         description: Operator
         type: string
         example: admin
+      product:
+        description: The product of the device under test. Added in version 2.
+        type: string
+        example: cRIO-9030
       fileIds:
         description: Array of file ids attached to the test result
         type: array
@@ -367,6 +372,10 @@ definitions:
         description: Name of the operator running the test
         type: string
         example: admin
+      product:
+        description: The product of the device under test. Added in version 2.
+        type: string
+        example: cRIO-9030
       serialNumber:
         description: Sequential number of the device under test
         type: string
@@ -451,6 +460,10 @@ definitions:
         description: Operator
         type: string
         example: admin
+      product:
+        description: The product of the device under test. Added in version 2.
+        type: string
+        example: cRIO-9030
       fileIds:
         description: Array of file ids attached to the test result
         type: array
@@ -500,6 +513,13 @@ definitions:
           type: string
         example:
           - 1f05c3c8-7a8c-4ebb-a87f-7a60d5dd8938
+      products:
+        description: Array of products. Added in version 2.
+        type: array
+        items:
+          type: string
+        example:
+          - cRIO-9030
       systemIds:
         description: Array of system ids
         type: array


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds the Product field to the result object.

### Why should this Pull Request be merged?

Syncing public documentation with backend changes.

### What testing has been done?

Both manual and automated testing of the service + various API components, with the new field.
