### PR TITLE
Fix alarm 401s to no longer nest the response ref under a schema

### DIFF
--- a/alarm/nialarm.yml
+++ b/alarm/nialarm.yml
@@ -574,9 +574,7 @@ paths:
                   type: string
                 example: [5c40ec55e0d6441168b4c549]
         401:
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/Error'
+          $ref: '#/responses/Unauthorized'
         default:
           $ref: '#/responses/Error'
   /v1/instances:
@@ -662,9 +660,7 @@ paths:
                 type: string
                 example: 5c40ec55e0d6441168b4c543
         401:
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/Error'
+          $ref: '#/responses/Unauthorized'
         409:
           description: For requests which would result in an update to an existing alarm instance, this is
             returned when the request does not represent a valid transition for the existing alarm instance.


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Cleans up a few 401 responses which were not properly defined in the alarm doc.

### Why should this Pull Request be merged?

This will give folks more accurate documentation for the affected 401 responses.

### What testing has been done?

None other than linting in editor.swagger.io.