### PR TITLE
Add API key support to Tag Historian

### DIFF
--- a/tag-historian/nitaghistorian.yml
+++ b/tag-historian/nitaghistorian.yml
@@ -13,9 +13,14 @@ consumes:
 produces:
   - application/json
 securityDefinitions:
+  apiKeyAuth:
+    type: apiKey
+    name: x-ni-api-key
+    in: header
   basicAuth:
     type: basic
 security:
+  - apiKeyAuth: []
   - basicAuth: []
 definitions:
   Error:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR adds API key support to the Tag Historian endpoint. It was copied directly from other endpoints that support API keys.

### Why should this Pull Request be merged?

The endpoint currently supports API keys, and it'd be nice to test it from within the OpenAPI doc.

### What testing has been done?

I've checked the code for syntax errors.