### PR TITLE
Fix packages Tags field

### DIFF
--- a/systems-management/nisysmgmt.yml
+++ b/systems-management/nisysmgmt.yml
@@ -1185,9 +1185,12 @@ definitions:
           description: The name of a package this package suggests. This also contains information about the version of the package.
           example: "ni-systemlink-client-2018.5-realtime-bin (>= 18.5.0)"       
       tags:
-        type: string
-        description: Tags of the package.
-        example: "KillBits, Security Update 2013"    
+        type: array
+        description: An array containing tags for the package.
+        items:
+          type: string
+          description: Tag for the package.
+          example: ".NET"
       userVisible:
         type: boolean
         description: The installed packages with this attribute set to true are considered to be installed by a user, thus not installed to fulfill some dependency. This is needed input for the calculation of unneeded packages when removing a package.


### PR DESCRIPTION
Tags are a list of strings. For some reason
they were defined as string before.

Signed-off-by: Rares POP <rares.pop@ni.com>

### What testing has been done?
The 'Software' pane for systems were error-ing out due to deserialization issues.
Now you can see the feeds, packages, add feeds and install software.