### PR TITLE
Set timeout values in Swagger. Use the same values as in old WebService.

### DIFF
--- a/systems-management/nisysmgmt.yml
+++ b/systems-management/nisysmgmt.yml
@@ -1632,6 +1632,7 @@ paths:
     post:
       operationId: UnregisterSystems
       x-ni-privilege: Write
+      x-ni-request-timeout: 180000
       x-ni-operation: manageSystems
       tags: [systems]
       summary: Unregister Systems
@@ -1772,6 +1773,7 @@ paths:
     post:
       operationId: ConfigureAndUpdateMultipleFeeds
       x-ni-privilege: Read
+      x-ni-request-timeout: 360000
       x-ni-operation: manageFeeds
       tags: [feeds]
       summary: Configure and update multiple feeds
@@ -2055,6 +2057,7 @@ paths:
     post:
       operationId: ManageSystemsKeys
       x-ni-privilege: Write
+      x-ni-request-timeout: 300000
       x-ni-operation: manageSystems
       tags: [systems]
       summary: Manage systems keys
@@ -2119,6 +2122,7 @@ paths:
     post:
       operationId: GetAvailablePackagesByQuery
       x-ni-privilege: Read
+      x-ni-request-timeout: 300000
       x-ni-operation: manageFeeds
       tags: [feeds]
       summary: Get Available Packages


### PR DESCRIPTION
Signed-off-by: Cristian Hotea <cristian.hotea@ni.com>

### What does this Pull Request accomplish?

Set timeout values to routes that take more than the default 30000 ms to execute.
