### PR TITLE
Adding API Key Auth support to TDMReader WS

### DIFF
--- a/tdm-reader/nitdmreader.yml
+++ b/tdm-reader/nitdmreader.yml
@@ -13,6 +13,10 @@ consumes:
 produces:
   - application/json
 securityDefinitions:
+  apiKeyAuth:
+    type: apiKey
+    name: x-ni-api-key
+    in: header
   basicAuth:
     type: basic
   cookieAuth:
@@ -20,6 +24,7 @@ securityDefinitions:
     in: header
     name: Cookie
 security:
+  - apiKeyAuth: []
   - basicAuth: []
   - cookieAuth: []
 x-ni-routing-key: Skyline.TDMReader


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This PR adds API key support to the Tag Historian endpoint. It was copied directly from other endpoints that support API keys.

### Why should this Pull Request be merged?

The endpoint currently supports API keys, and it'd be nice to test it from within the OpenAPI doc.

### What testing has been done?

I've checked the code for syntax errors on https://editor.swagger.io.