### PR TITLE
Request REMOTE_USER variables for posting a job

### DIFF
--- a/systems-management/nisysmgmt.yml
+++ b/systems-management/nisysmgmt.yml
@@ -1554,6 +1554,7 @@ paths:
       operationId: CreateJob
       x-ni-privilege: Write
       x-ni-operation: createOrCancelJobs
+      x-ni-request-variables: [REMOTE_USER]
       tags: [jobs]
       summary: Create a job
       description: Create a job and returns the newly created job including the job ID.


### PR DESCRIPTION
- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Request variable **REMOTE_USER** for route `/v1/jobs` (POST method).

### Why should this Pull Request be merged?

We need the username to be displayed in the jobs history grid.

### What testing has been done?

I re-compiled the solution and I was able to access the **REMOTE_USER** variable. 
