### PR TITLE
Add apiKeyAuth to the alarm swagger doc

### DIFF
--- a/alarm/nialarm.yml
+++ b/alarm/nialarm.yml
@@ -15,8 +15,13 @@ produces:
 securityDefinitions:
   basicAuth:
     type: basic
+  apiKeyAuth:
+    type: apiKey
+    name: x-ni-api-key
+    in: header
 security:
   - basicAuth: []
+  - apiKeyAuth: []
 x-ni-routing-key: Skyline.AlarmInstance
 definitions:
   Error:


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?
This PR adds apiKeyAuth to the alarm service's swagger doc. I'm hoping this will enable the codegen'd python API to automatically detect if it's running on the minion or master.

### Why should this Pull Request be merged?

This resolves AzDO 898524: Alarm service not listening for api key auth

### What testing has been done?

Linted in editor.swagger.io and verified that apiKeyAuth was an authorization option in Swagger UI
