### PR TITLE
Escape yaml key 'y' to avoid boolean conversion

### DIFF
--- a/tdm-reader/nitdmreader.yml
+++ b/tdm-reader/nitdmreader.yml
@@ -258,7 +258,7 @@ definitions:
     properties:
       x:
         $ref: '#/definitions/OneChannelData'
-      y:
+      'y':
         type: array
         description: Array of y channels
         items:


### PR DESCRIPTION
According to the yaml spec, the key "y" will be converted to a boolean key. Escaping y so that it is treated as a string.

See https://yaml.org/type/bool.html

Some yaml parses will otherwise reject this file.

- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).