### PR TITLE
Fix delete response status code

### DIFF
--- a/auth/niauth.yaml
+++ b/auth/niauth.yaml
@@ -154,7 +154,7 @@ paths:
       parameters:
         - $ref: '#/parameters/KeyId'
       responses:
-        201:
+        204:
           description: Success
         401:
           $ref: '#/responses/Unauthorized'
@@ -274,7 +274,7 @@ paths:
       parameters:
         - $ref: '#/parameters/PolicyId'
       responses:
-        201:
+        204:
           description: Success
         401:
           $ref: '#/responses/Unauthorized'
@@ -394,7 +394,7 @@ paths:
       parameters:
         - $ref: '#/parameters/PolicyTemplateId'
       responses:
-        201:
+        204:
           description: Success
         401:
           $ref: '#/responses/Unauthorized'

--- a/user/niuser.yaml
+++ b/user/niuser.yaml
@@ -133,7 +133,7 @@ paths:
           in: path
           description: The user id
       responses:
-        201:
+        204:
           description: Success
         401:
           $ref: '#/responses/Unauthorized'
@@ -271,7 +271,7 @@ paths:
       parameters:
         - $ref: '#/parameters/AuthMappingId'
       responses:
-        201:
+        204:
           description: Success
         401:
           $ref: '#/responses/Unauthorized'


### PR DESCRIPTION
The user service and auth service delete routes correctly return
204. Fixing the swagger definition.

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).