### PR TITLE
Document GET /niauth/v1/policy-templates builtIn param

### DIFF
--- a/auth/niauth.yaml
+++ b/auth/niauth.yaml
@@ -300,6 +300,10 @@ paths:
           description: Filters the policy-templates by type. Can be a comma-separated list of types.
           type: string
         - in: query
+          name: builtIn
+          description: Filters the policy-templates by the builtIn flag.
+          type: boolean
+        - in: query
           name: id
           description: Filters the policy-templates by id. Can be a comma-separated list of ids.
           type: string
@@ -446,6 +450,9 @@ definitions:
       type:
         type: string
         description: The type of the policy template
+      builtIn:
+        type: boolean
+        description: Whether the policy template is built-in
       userId:
         type: string
         description: The user id

--- a/auth/niauth.yaml
+++ b/auth/niauth.yaml
@@ -180,6 +180,10 @@ paths:
           description: Filters the policies by type. Can be a comma-separated list of types.
           type: string
         - in: query
+          name: builtIn
+          description: Filters the policies by the builtIn flag.
+          type: boolean
+        - in: query
           name: id
           description: Filters the policies by id. Can be a comma-separated list of ids.
           type: string
@@ -516,6 +520,9 @@ definitions:
       type:
         type: string
         description: The type of the policy
+      builtIn:
+        type: boolean
+        description: Whether the policy is built-in
       userId:
         type: string
         description: The user id


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add the `builtIn` property for policies and policy templates

### Why should this Pull Request be merged?

The niauth service was changes and now supports this field

### What testing has been done?

Validated swagger UI in online editor
