### PR TITLE
Move administrative routes that require whitelisted API keys under a different tag, at the end of list

### DIFF
--- a/auth/niauth.yaml
+++ b/auth/niauth.yaml
@@ -32,25 +32,6 @@ paths:
         default:
           $ref: '#/responses/Error'
 
-  /session-keys:
-    post:
-      tags:
-        - keys
-      summary: Creates temporary API Keys
-      description: Create a temporary session key which is valid for 1 hour. The caller needs a whitelisted API key to issue session keys.
-      operationId: create-session-key
-      parameters:
-        - $ref: '#/parameters/CreateSessionKeyRequest'
-      responses:
-        200:
-          $ref: '#/responses/CreateSessionKeyResponse'
-        400:
-          $ref: '#/responses/ValidationError'
-        401:
-          $ref: '#/responses/Unauthorized'
-        default:
-          $ref: '#/responses/Error'
-
   /keys:
     get:
       tags:

--- a/auth/niauth.yaml
+++ b/auth/niauth.yaml
@@ -32,25 +32,6 @@ paths:
         default:
           $ref: '#/responses/Error'
 
-  /session-keys:
-    post:
-      tags:
-        - keys
-      summary: Creates temporary API Keys
-      description: Create a temporary session key which is valid for 1 hour. The caller needs a whitelisted API key to issue session keys.
-      operationId: create-session-key
-      parameters:
-        - $ref: '#/parameters/CreateSessionKeyRequest'
-      responses:
-        200:
-          $ref: '#/responses/CreateSessionKeyResponse'
-        400:
-          $ref: '#/responses/ValidationError'
-        401:
-          $ref: '#/responses/Unauthorized'
-        default:
-          $ref: '#/responses/Error'
-
   /keys:
     get:
       tags:
@@ -400,6 +381,25 @@ paths:
           $ref: '#/responses/Unauthorized'
         404:
           $ref: '#/responses/NotFound'
+        default:
+          $ref: '#/responses/Error'
+
+  /session-keys:
+    post:
+      tags:
+        - whitelisted operations
+      summary: Creates temporary API Keys
+      description: Create a temporary session key which is valid for 1 hour. The caller needs a whitelisted API key to issue session keys.
+      operationId: create-session-key
+      parameters:
+        - $ref: '#/parameters/CreateSessionKeyRequest'
+      responses:
+        200:
+          $ref: '#/responses/CreateSessionKeyResponse'
+        400:
+          $ref: '#/responses/ValidationError'
+        401:
+          $ref: '#/responses/Unauthorized'
         default:
           $ref: '#/responses/Error'
 

--- a/auth/niauth.yaml
+++ b/auth/niauth.yaml
@@ -32,6 +32,25 @@ paths:
         default:
           $ref: '#/responses/Error'
 
+  /session-keys:
+    post:
+      tags:
+        - keys
+      summary: Creates temporary API Keys
+      description: Create a temporary session key which is valid for 1 hour. The caller needs a whitelisted API key to issue session keys.
+      operationId: create-session-key
+      parameters:
+        - $ref: '#/parameters/CreateSessionKeyRequest'
+      responses:
+        200:
+          $ref: '#/responses/CreateSessionKeyResponse'
+        400:
+          $ref: '#/responses/ValidationError'
+        401:
+          $ref: '#/responses/Unauthorized'
+        default:
+          $ref: '#/responses/Error'
+
   /keys:
     get:
       tags:

--- a/user/niuser.yaml
+++ b/user/niuser.yaml
@@ -17,27 +17,6 @@ security:
 schemes:
   - https
 paths:
-  '/orgs/{name}':
-    get:
-      tags:
-        - orgs
-      summary: 'Get organization'
-      operationId: get-org
-      description: Returns the organization with the given name
-      parameters:
-        - in: path
-          required: true
-          name: name
-          description: The org name, e.g. 'SystemLink Server'
-          type: string
-      responses:
-        200:
-          $ref: '#/responses/GetOrgResponse'
-        404:
-          $ref: '#/responses/NotFound'
-        default:
-          $ref: '#/responses/Error'
-
   '/users/query':
     post:
       tags:

--- a/user/niuser.yaml
+++ b/user/niuser.yaml
@@ -17,6 +17,27 @@ security:
 schemes:
   - https
 paths:
+  '/orgs/{name}':
+    get:
+      tags:
+        - orgs
+      summary: 'Get organization'
+      operationId: get-org
+      description: Returns the organization with the given name
+      parameters:
+        - in: path
+          required: true
+          name: name
+          description: The org name, e.g. 'SystemLink Server'
+          type: string
+      responses:
+        200:
+          $ref: '#/responses/GetOrgResponse'
+        404:
+          $ref: '#/responses/NotFound'
+        default:
+          $ref: '#/responses/Error'
+
   '/users/query':
     post:
       tags:

--- a/user/niuser.yaml
+++ b/user/niuser.yaml
@@ -17,27 +17,6 @@ security:
 schemes:
   - https
 paths:
-  '/orgs/{name}':
-    get:
-      tags:
-        - orgs
-      summary: 'Get organization'
-      operationId: get-org
-      description: Returns the organization with the given name
-      parameters:
-        - in: path
-          required: true
-          name: name
-          description: The org name, e.g. 'SystemLink Server'
-          type: string
-      responses:
-        200:
-          $ref: '#/responses/GetOrgResponse'
-        404:
-          $ref: '#/responses/NotFound'
-        default:
-          $ref: '#/responses/Error'
-
   '/users/query':
     post:
       tags:
@@ -275,6 +254,27 @@ paths:
           description: Success
         401:
           $ref: '#/responses/Unauthorized'
+        404:
+          $ref: '#/responses/NotFound'
+        default:
+          $ref: '#/responses/Error'
+
+  '/orgs/{name}':
+    get:
+      tags:
+        - whitelisted operations
+      summary: 'Get organization'
+      operationId: get-org
+      description: Returns the organization with the given name. The caller needs a whitelisted API key to read organizations.
+      parameters:
+        - in: path
+          required: true
+          name: name
+          description: The org name, e.g. 'SystemLink Server'
+          type: string
+      responses:
+        200:
+          $ref: '#/responses/GetOrgResponse'
         404:
           $ref: '#/responses/NotFound'
         default:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Move routes that require whitelisted keys at the end of the list and mark them as whitelisted operations

### Why should this Pull Request be merged?

- These routes could lead to confusion because it's not obvious if customers can use them or not
- Customer have other ways of creating keys and using them to access resources (e.g. Serevr Administrators can issue permanent API Keys using the `POST niauth/v1/keys` route)

#### Example
![image](https://user-images.githubusercontent.com/11149800/86216103-2b054980-bb86-11ea-9113-a2fc8090f271.png)
