### PR TITLE
Fix niuser query documentation

### DIFF
--- a/user/niuser.yaml
+++ b/user/niuser.yaml
@@ -408,9 +408,9 @@ parameters:
 
               - Logical OR operator 'or'. Example: 'x or y'
 
-              - Contains operator '.Contains()', used to check whether a string contains another string. Example: 'x.Contains(y)'
+              - Starts with operator '.StartsWith()', used to check whether a string starts with another string. Example: 'x.StartsWith(y)'
 
-              - Does not contain operator '!.Contains()', used to check whether a string does not contain another string. Example: '!x.Contains(y)'
+              - Does not start with operator '!.StartsWith()', used to check whether a string does not start with another string. Example: '!x.StartsWith(y)'
 
               - String null or empty 'string.IsNullOrEmpty()', used to check whether a string is null or empty. Example: 'string.IsNullOrEmpty(x)'
 
@@ -433,7 +433,7 @@ parameters:
 
               - status
           type: string
-          example: firstName.Contains("John") && status == "active"
+          example: firstName.StartsWith("John") && status == "active"
         take:
           description: The maximum number of users to return
           type: integer


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Fix incorrect documentation listing `string.Contains` as a supported method for user queries. I have replaced it with `string.StartsWith`, consistent with the webapp documentation.

### Why should this Pull Request be merged?

We should provide correct documentation and examples that can actually be executed.

### What testing has been done?

![image](https://user-images.githubusercontent.com/32167177/88231045-212cae80-cc39-11ea-9e26-b5389ff633d6.png)

I also ran the example query against the user service.