### PR TITLE
Fix syntax error in nirepo swagger file

### DIFF
--- a/repo/nirepo.yml
+++ b/repo/nirepo.yml
@@ -936,7 +936,7 @@ paths:
           description: The request encountered an error.
         default:
           $ref: '#/definitions/Error'
-  /v1/files:
+  /v1/files/{pathToFile}:
     parameters:
       - in: path
         name: pathToFile


### PR DESCRIPTION

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

TODO: Check the above box with an 'x' indicating you've read and followed [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Currently when trying to generate code using editor.swagger.io from this file it pops up the following syntax error: 
```
Semantic error at paths./v1/files.parameters.0.name
Path parameter "pathToFile" must have the corresponding {pathToFile} segment in the "/v1/files" path
Jump to line 942
```

### Why should this Pull Request be merged?

This issue has been found while trying to help a customer use the nirepo swagger document to generate Java code

### What testing has been done?
- Ensured that there are no syntax errors in tje document by pasting it into editor.swagger.io.
- Tested that I can generate java code from the swagger document.
