### PR TITLE
Add "oidc-claim" type to niuser.yaml

### DIFF
--- a/user/niuser.yaml
+++ b/user/niuser.yaml
@@ -572,7 +572,7 @@ parameters:
       properties:
         type:
           type: string
-          enum: [user, windows-group, windows-user, ldap-group, ldap-attribute, ldap-user]
+          enum: [user, windows-group, windows-user, ldap-group, ldap-attribute, ldap-user, oidc-claim]
           description: The Auth Mapping type
         policyId:
           type: string
@@ -605,7 +605,7 @@ parameters:
       properties:
         type:
           type: string
-          enum: [user, windows-group, windows-user, ldap-group, ldap-attribute, ldap-user]
+          enum: [user, windows-group, windows-user, ldap-group, ldap-attribute, ldap-user, oidc-claim]
           description: The Auth Mapping type
         policyId:
           type: string


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add "oidc-claim" mapping type to user services swagger doc.

### Why should this Pull Request be merged?

The support for this mapping type has already been added to the service. This is required to add OpenID Connect support to the service.

### What testing has been done?

Verified no syntax errors by pasting into edditor.swagger.io
