### PR TITLE
Add BasicAuth to all APIs without it (niauth, niuser, and niapp)

### DIFF
--- a/auth/niauth.yaml
+++ b/auth/niauth.yaml
@@ -12,8 +12,11 @@ securityDefinitions:
     type: apiKey
     name: x-ni-api-key
     in: header
+  BasicAuth:
+    type: basic
 security:
   - ApiKeyAuth: []
+  - BasicAuth: []
 paths:
   /auth:
     get:

--- a/user/niuser.yaml
+++ b/user/niuser.yaml
@@ -12,8 +12,11 @@ securityDefinitions:
     type: apiKey
     name: x-ni-api-key
     in: header
+  BasicAuth:
+    type: basic
 security:
   - ApiKeyAuth: []
+  - BasicAuth: []
 paths:
   '/users/query':
     post:

--- a/webapp/niapp.yaml
+++ b/webapp/niapp.yaml
@@ -12,8 +12,11 @@ securityDefinitions:
     type: apiKey
     name: x-ni-api-key
     in: header
+  BasicAuth:
+    type: basic
 security:
   - ApiKeyAuth: []
+  - BasicAuth: []
 paths:
   '/webapps/{id}':
     get:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add BasicAuth to the 3 APIs missing it: `niauth`, `niuser`, and `niapp`. 

### Why should this Pull Request be merged?

It's inconsistent to forbid it for these but allow it for the rest.

### What testing has been done?

Tested generating python client code by running the new yaml files through the [Swagger Editor](https://editor.swagger.io/). The documentation for it now gives instructions for basic auth:
![image](https://user-images.githubusercontent.com/905712/115300091-2f0a5400-a125-11eb-8d45-b1c9d9545726.png)
![image](https://user-images.githubusercontent.com/905712/115300153-3e899d00-a125-11eb-83fc-eccf802af7ae.png)

Tested running in python 3.8 that basic auth can be used with all 3 APIs. For each of the 3, I tested one of the endpoints:
- `query` for `niapp`
- `get_workspaces` for `niuser`
- `auth` for `niauth`