### PR TITLE
Remove basic auth from Tag Historian

### DIFF
--- a/tag-historian/nitaghistorian.yml
+++ b/tag-historian/nitaghistorian.yml
@@ -17,11 +17,8 @@ securityDefinitions:
     type: apiKey
     name: x-ni-api-key
     in: header
-  basicAuth:
-    type: basic
 security:
   - apiKeyAuth: []
-  - basicAuth: []
 definitions:
   Error:
     description: Contains error information


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Removes the basic auth from the authorization dialog
### Why should this Pull Request be merged?

Because basic auth is not supported anymore
### What testing has been done?

Before:
![image](https://github.com/ni/systemlink-OpenAPI-documents/assets/89146546/6e67224e-c944-4323-9efa-b32a30992555)

After:
![image](https://github.com/ni/systemlink-OpenAPI-documents/assets/89146546/5b826be6-6ca2-4abd-a040-7ad632a20e0f)
