### PR TITLE
removing deprecated contact email address - replace with link to NI support page

### DIFF
--- a/alarm/nialarm.yml
+++ b/alarm/nialarm.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: 'https://www.ni.com/systemlink'
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: /nialarm
 consumes:
   - application/json

--- a/asset-management-rule/niapmrule.yml
+++ b/asset-management-rule/niapmrule.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: 'https://www.ni.com/systemlink'
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: /niapmrule
 consumes:
   - application/json

--- a/asset-managment/niapm.yml
+++ b/asset-managment/niapm.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: 'https://www.ni.com/systemlink'
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: /niapm
 x-ni-privilege-application: 'niws.niasset'
 consumes:

--- a/auth/niauth.yaml
+++ b/auth/niauth.yaml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: https://www.ni.com/systemlink
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: /niauth/v1
 consumes:
   - application/json

--- a/file/nifile.yml
+++ b/file/nifile.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: https://www.ni.com/systemlink
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: /nifile
 consumes: [application/json]
 produces: [application/json]

--- a/message/nimessage.yml
+++ b/message/nimessage.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: 'https://www.ni.com/systemlink'
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: /nimessage
 consumes:
   - application/json

--- a/ni-notebook-execution/ninbexec.yml
+++ b/ni-notebook-execution/ninbexec.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: https://www.ni.com/systemlink
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: /ninbexec
 x-ni-routing-key: Skyline.NotebookExecution
 consumes: [application/json]

--- a/opcclient/niopcclient.yml
+++ b/opcclient/niopcclient.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: https://www.ni.com/systemlink
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: /niopcclient
 x-ni-routing-key: 'Skyline.OpcClient'
 consumes: [application/json]

--- a/repo/nirepo.yml
+++ b/repo/nirepo.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: https://www.ni.com/systemlink
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: "/nirepo"
 consumes: [application/json]
 produces: [application/json]

--- a/service-registry/niserviceregistry.yml
+++ b/service-registry/niserviceregistry.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: 'https://www.ni.com/systemlink'
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: /niserviceregistry
 consumes:
   - application/json

--- a/systems-management/nisysmgmt.yml
+++ b/systems-management/nisysmgmt.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: https://www.ni.com/systemlink
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: '/nisysmgmt'
 x-ni-routing-key: 'Skyline.Salt'
 consumes: [application/json]

--- a/systems-state/nisystemsstate.yml
+++ b/systems-state/nisystemsstate.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: https://www.ni.com/systemlink
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: "/nisystemsstate"
 x-ni-routing-key: 'Skyline.SystemsStateManager'
 x-ni-privilege-application: 'niws.nisysmgmt'

--- a/tag-historian/nitaghistorian.yml
+++ b/tag-historian/nitaghistorian.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: 'https://www.ni.com/systemlink'
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: /nitaghistorian
 consumes:
   - application/json

--- a/tag-rule/nitagrule.yml
+++ b/tag-rule/nitagrule.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: 'https://www.ni.com/systemlink'
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: /nitagrule
 consumes:
   - application/json

--- a/tag/nitag.yml
+++ b/tag/nitag.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: 'https://www.ni.com/systemlink'
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: /nitag
 consumes:
   - application/json

--- a/tdm-reader/nitdmreader.yml
+++ b/tdm-reader/nitdmreader.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: 'https://www.ni.com/systemlink'
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: /nitdmreader
 consumes:
   - application/json

--- a/test-monitor/nitestmonitor-v1.yml
+++ b/test-monitor/nitestmonitor-v1.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: 'https://www.ni.com/systemlink'
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: /nitestmonitor
 consumes:
   - application/json

--- a/test-monitor/nitestmonitor-v2.yml
+++ b/test-monitor/nitestmonitor-v2.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: 'https://www.ni.com/systemlink'
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: /nitestmonitor
 consumes:
   - application/json

--- a/user-data/niuserdata.yml
+++ b/user-data/niuserdata.yml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: https://www.ni.com/systemlink
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: /niuserdata
 x-ni-routing-key: Skyline.UserData
 consumes: [application/json]

--- a/user/niuser.yaml
+++ b/user/niuser.yaml
@@ -6,7 +6,9 @@ info:
   contact:
     name: NI
     url: https://www.ni.com/systemlink
-    email: support@ni.com
+externalDocs:
+  description: Technical Support
+  url: https://ni.com/support
 basePath: /niuser/v1
 consumes:
   - application/json


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/systemlink-OpenAPI-documents/blob/master/CONTRIBUTING.md).


### What does this Pull Request accomplish?

correcting support information, so customers are correctly informed, where to get help

### Why should this Pull Request be merged?

current email address is deprecated

### What testing has been done?

tested all documents by pasting them into [editor.swagger.io](https://editor.swagger.io/)
niopcclient.yml throws an error, but the error is already existing in the old versions
